### PR TITLE
refac(backend, frontend): improve PWA manifest strategy

### DIFF
--- a/backend/api/service/pwa_manifest.py
+++ b/backend/api/service/pwa_manifest.py
@@ -27,19 +27,15 @@ from __future__ import annotations
 import hashlib
 import json
 from typing import Any, TypedDict
-from urllib.parse import urlsplit, urlunsplit
 
 from api.service.web_assets import (
 	STATIC_ASSET_PATH,
-	app_url,
 	cdn_asset_url,
 	default_asset_url,
 	resolve_asset_source,
 )
 from api.settings import settings
 from api.settings.settings import (
-	DEFAULT_API_PORT,
-	DEFAULT_FRONTEND_PORT,
 	ManifestAssetSettings,
 	PwaManifestAssetsSettings,
 )
@@ -53,12 +49,13 @@ class ManifestCacheEntry(TypedDict):
 	etag: str
 
 
-_cache: dict[str, ManifestCacheEntry] = {}
+_cache: ManifestCacheEntry | None = None
 
 
 def invalidate_cache() -> None:
 	"""clear cached manifest so the next request recompiles."""
-	_cache.clear()
+	global _cache
+	_cache = None
 
 
 # -- public API --
@@ -66,14 +63,13 @@ def invalidate_cache() -> None:
 
 def get_manifest_response(request_origin: str | None = None) -> tuple[bytes, str]:
 	"""return (body_bytes, etag) for the current manifest."""
-	frontend = _resolve_frontend_origin(request_origin)
-	if frontend not in _cache:
-		manifest = _compile(frontend)
+	global _cache
+	if _cache is None:
+		manifest = _compile()
 		body = json.dumps(manifest, separators=(",", ":")).encode()
 		etag = hashlib.sha256(body).hexdigest()[:16]
-		_cache[frontend] = {"body": body, "etag": etag}
-	entry = _cache[frontend]
-	return entry["body"], entry["etag"]
+		_cache = {"body": body, "etag": etag}
+	return _cache["body"], _cache["etag"]
 
 
 # -- internals --
@@ -155,26 +151,6 @@ _WIDE_SCREENSHOTS = 8
 _WIDE_SIZE = "3840x2160"
 
 
-def _resolve_frontend_origin(request_origin: str | None) -> str:
-	if settings.branding.public_frontend_origin:
-		return str(settings.branding.public_frontend_origin).rstrip("/")
-	return _frontend_origin_from_api_origin(
-		request_origin or f"http://localhost:{DEFAULT_API_PORT}"
-	)
-
-
-def _frontend_origin_from_api_origin(origin: str) -> str:
-	parsed = urlsplit(origin.rstrip("/"))
-	if not parsed.scheme or not parsed.netloc:
-		parsed = urlsplit(f"http://localhost:{DEFAULT_API_PORT}")
-	host = parsed.hostname or "localhost"
-	if ":" in host and not host.startswith("["):
-		host = f"[{host}]"
-	return urlunsplit(
-		(parsed.scheme, f"{host}:{DEFAULT_FRONTEND_PORT}", "", "", "")
-	).rstrip("/")
-
-
 def _guess_mime(filename: str) -> str:
 	lower = filename.lower()
 	if lower.endswith(".svg"):
@@ -227,7 +203,6 @@ def _build_icons(
 
 
 def _build_shortcuts(
-	frontend: str,
 	cdn: str | None,
 	assets: PwaManifestAssetsSettings,
 ) -> list[dict[str, Any]]:
@@ -245,14 +220,14 @@ def _build_shortcuts(
 	for spec, asset, file in shortcut_specs:
 		icon_src = _resolve_manifest_asset(
 			asset,
-			app_url(frontend, spec["icon_file"]),
+			spec["icon_file"],
 			cdn_asset_url(cdn, STATIC_ASSET_PATH, "shortcuts", file) if cdn else None,
 		)
 		entry: dict[str, Any] = {
 			"name": spec["name"],
 			"short_name": spec["short_name"],
 			"description": spec["description"],
-			"url": app_url(frontend, spec["url"]),
+			"url": spec["url"],
 		}
 		if icon_src:
 			entry["icons"] = [
@@ -327,7 +302,7 @@ def _build_screenshots(
 	return shots
 
 
-def _compile(frontend: str) -> dict[str, Any]:
+def _compile() -> dict[str, Any]:
 	"""build a complete PWA manifest from current settings."""
 	branding = settings.branding
 	cdn = (
@@ -343,8 +318,8 @@ def _compile(frontend: str) -> dict[str, Any]:
 		"short_name": branding.site_name,
 		"description": "your interface with AI",
 		"orientation": "natural",
-		"start_url": f"{frontend}/",
-		"scope": f"{frontend}/",
+		"start_url": "/",
+		"scope": "/",
 		"display_override": ["window-controls-overlay", "standalone"],
 		"display": "standalone",
 		"theme_color": branding.primary_color,
@@ -358,7 +333,7 @@ def _compile(frontend: str) -> dict[str, Any]:
 		"protocol_handlers": [
 			{
 				"protocol": "web+nokodo",
-				"url": f"{frontend}/?protocol=%s",
+				"url": "/?protocol=%s",
 			},
 		],
 	}
@@ -369,6 +344,6 @@ def _compile(frontend: str) -> dict[str, Any]:
 	screenshots = _build_screenshots(cdn, pwa_assets)
 	if screenshots:
 		manifest["screenshots"] = screenshots
-	manifest["shortcuts"] = _build_shortcuts(frontend, cdn, pwa_assets)
+	manifest["shortcuts"] = _build_shortcuts(cdn, pwa_assets)
 
 	return manifest

--- a/backend/api/tests/test_pwa_manifest.py
+++ b/backend/api/tests/test_pwa_manifest.py
@@ -29,8 +29,8 @@ def test_manifest_defaults_use_nokodo_assets_and_frontend_shortcuts(
 		manifest = json.loads(body)
 
 		assert manifest["id"] == "/"
-		assert manifest["start_url"] == "https://nokodo.dev/"
-		assert manifest["scope"] == "https://nokodo.dev/"
+		assert manifest["start_url"] == "/"
+		assert manifest["scope"] == "/"
 		assert manifest["display_override"] == [
 			"window-controls-overlay",
 			"standalone",
@@ -38,7 +38,7 @@ def test_manifest_defaults_use_nokodo_assets_and_frontend_shortcuts(
 		assert manifest["protocol_handlers"] == [
 			{
 				"protocol": "web+nokodo",
-				"url": "https://nokodo.dev/?protocol=%s",
+				"url": "/?protocol=%s",
 			},
 		]
 		assert manifest["icons"] == [
@@ -62,18 +62,18 @@ def test_manifest_defaults_use_nokodo_assets_and_frontend_shortcuts(
 			"https://nokodo.net/static/os1/screenshots/wide-8-3840x2160.png"
 		)
 		assert [shortcut["url"] for shortcut in manifest["shortcuts"]] == [
-			"https://nokodo.dev/notes",
-			"https://nokodo.dev/reminders",
-			"https://nokodo.dev/calendar",
-			"https://nokodo.dev/messages",
-			"https://nokodo.dev/projects",
-			"https://nokodo.dev/library",
-			"https://nokodo.dev/social",
-			"https://nokodo.dev/settings",
+			"/notes",
+			"/reminders",
+			"/calendar",
+			"/messages",
+			"/projects",
+			"/library",
+			"/social",
+			"/settings",
 		]
 		assert manifest["shortcuts"][0]["icons"] == [
 			{
-				"src": "https://nokodo.dev/shortcuts/notes.png",
+				"src": "/shortcuts/notes.png",
 				"sizes": "192x192",
 				"type": "image/png",
 			}
@@ -82,7 +82,7 @@ def test_manifest_defaults_use_nokodo_assets_and_frontend_shortcuts(
 		pwa_manifest.invalidate_cache()
 
 
-def test_manifest_falls_back_to_request_host_default_frontend_port(
+def test_manifest_uses_relative_urls_regardless_of_request_origin(
 	monkeypatch: pytest.MonkeyPatch,
 ) -> None:
 	branding = BrandingSettings.model_validate(
@@ -98,11 +98,11 @@ def test_manifest_falls_back_to_request_host_default_frontend_port(
 		body, _etag = pwa_manifest.get_manifest_response("http://localhost:1383")
 		manifest = json.loads(body)
 
-		assert manifest["start_url"] == "http://localhost:888/"
-		assert manifest["scope"] == "http://localhost:888/"
-		assert manifest["shortcuts"][0]["url"] == "http://localhost:888/notes"
+		assert manifest["start_url"] == "/"
+		assert manifest["scope"] == "/"
+		assert manifest["shortcuts"][0]["url"] == "/notes"
 		assert manifest["shortcuts"][0]["icons"][0]["src"] == (
-			"http://localhost:888/shortcuts/notes.png"
+			"/shortcuts/notes.png"
 		)
 	finally:
 		pwa_manifest.invalidate_cache()
@@ -159,7 +159,7 @@ def test_manifest_asset_sources_can_use_cdn_custom_and_disabled(
 				"type": "image/png",
 			}
 		]
-		assert manifest["shortcuts"][2]["url"] == "https://app.example.com/calendar"
+		assert manifest["shortcuts"][2]["url"] == "/calendar"
 		assert "icons" not in manifest["shortcuts"][2]
 
 		screenshot_sources = [shot["src"] for shot in manifest["screenshots"]]

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -368,7 +368,7 @@
 <svelte:head>
 	<title>{pageTitleStore.pageFullTitle}</title>
 	{#if mediaUrls.manifest}
-		<link rel="manifest" href={mediaUrls.manifest} />
+		<link rel="manifest" href={mediaUrls.manifest} crossorigin="use-credentials" />
 	{/if}
 	{#if mediaUrls.favicon}
 		<link rel="icon" href={mediaUrls.favicon} />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
 				target: 'http://localhost:1383',
 				changeOrigin: true,
 			},
+			// proxy manifest so it is same-origin in dev, enabling
+			// reliable PWA installability checks in Chrome.
+			'/system/manifest.json': {
+				target: 'http://localhost:1383',
+				changeOrigin: true,
+			},
 		},
 	},
 })


### PR DESCRIPTION
Refactor the PWA manifest to use relative URLs for `start_url`, `scope`, and `protocol_handlers`, enhancing cross-origin support with a `crossorigin` attribute in the manifest link. Introduce a development-only proxy for manifest requests to streamline local testing.



## type of change



- [ ] 🐛 bug fix (non-breaking change which fixes an issue)

- [ ] ✨ new feature (non-breaking change which adds functionality)

- [ ] 💥 breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] 📚 documentation update

- [x] ♻️ code refactor (no functional changes)

- [ ] 🎨 style/formatting changes

- [x] ⚡ performance improvement

- [ ] 🔧 configuration change



## changelog



### added



- Development-only proxy for manifest requests.



### changed



- Updated manifest to use relative URLs for `start_url`, `scope`, and `protocol_handlers`.

- Added `crossorigin` attribute to the manifest link.



### fixed



<!-- bug fixes -->



### removed



<!-- deprecated or removed features -->



## testing



- [ ] I have added/updated tests to cover my changes

- [ ] I have run all tests locally and they pass



## checklist



- [ ] **target branch is `dev`**

- [ ] PR title follows [semantic commit format](https://www.conventionalcommits.org/) (e.g., `feat: add user authentication`, `fix: resolve CORS issue`)

- [ ] Code follows the project's style guidelines

- [ ] Self-review completed

- [ ] Documentation updated (if applicable)

- [ ] No breaking changes (or clearly documented if unavoidable)

- [ ] Related issues linked (e.g., `closes #123`, `fixes #456`)



## additional notes



<!-- any additional information, screenshots, or context -->

